### PR TITLE
☕ Bump to Java 17

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,17 +12,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        #java: [16,17-ea] because upload-artifact uploads only the jar compiled with Java 17
-        java: [16]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 16
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: ${{ matrix.java }}
-          distribution: 'zulu'
+          java-version: 17
+          distribution: 'temurin'
       - uses: burrunan/gradle-cache-action@v1
         name: Build with Gradle
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ allprojects {
 
     java {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(16))
+            languageVersion.set(JavaLanguageVersion.of(17))
         }
     }
 }
@@ -49,7 +49,7 @@ subprojects {
 
     tasks.withType<JavaCompile> {
         options.encoding = Charsets.UTF_8.name()
-        options.release.set(16)
+        options.release.set(17)
     }
 
     // For Waterfall and Paper platforms: set version


### PR DESCRIPTION
Most servers are still on Java 16, so i will wait before merging this PR.
- [x] Make GH Actions build with JDK17.
- [x] Target Java 17 in gradle buildscript.